### PR TITLE
bug/AVAT-1297 [Intercom] [Android] Call notification UI is not visible

### DIFF
--- a/android/src/main/java/com/incomingcall/AnswerCallActivity.kt
+++ b/android/src/main/java/com/incomingcall/AnswerCallActivity.kt
@@ -29,7 +29,6 @@ class AnswerCallActivity : ReactActivity() {
   @SuppressLint("UnspecifiedRegisterReceiverFlag")
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(null)
-    IncomingCallModule.sendIntercomBroadcast(this, "Call answered")
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
       setShowWhenLocked(true)
@@ -49,6 +48,7 @@ class AnswerCallActivity : ReactActivity() {
         or WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
     )
 
+    IncomingCallModule.sendIntercomBroadcast(this, "Call screen shown")
 
     if (CallingActivity.active) {
       sendBroadcast(Intent(Constants.ACTION_END_CALL))

--- a/android/src/main/java/com/incomingcall/AnswerCallActivity.kt
+++ b/android/src/main/java/com/incomingcall/AnswerCallActivity.kt
@@ -29,6 +29,7 @@ class AnswerCallActivity : ReactActivity() {
   @SuppressLint("UnspecifiedRegisterReceiverFlag")
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(null)
+    IncomingCallModule.sendIntercomBroadcast(this, "Call answered")
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
       setShowWhenLocked(true)

--- a/android/src/main/java/com/incomingcall/AnswerCallActivity.kt
+++ b/android/src/main/java/com/incomingcall/AnswerCallActivity.kt
@@ -48,7 +48,7 @@ class AnswerCallActivity : ReactActivity() {
         or WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON
     )
 
-    IncomingCallModule.sendIntercomBroadcast(this, "Call screen shown")
+    IncomingCallModule.sendIntercomBroadcast(this, "Call Answered")
 
     if (CallingActivity.active) {
       sendBroadcast(Intent(Constants.ACTION_END_CALL))
@@ -81,6 +81,9 @@ class AnswerCallActivity : ReactActivity() {
   private val mBroadcastReceiver: BroadcastReceiver = object : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent) {
       if (intent.action == Constants.ACTION_END_CALL) {
+        context?.let {
+          IncomingCallModule.sendIntercomBroadcast(it, "Call Hangup")
+        }
         finishAndRemoveTask()
       }
     }

--- a/android/src/main/java/com/incomingcall/CallService.kt
+++ b/android/src/main/java/com/incomingcall/CallService.kt
@@ -20,6 +20,7 @@ import android.os.VibratorManager
 import android.widget.RemoteViews
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
+import java.lang.Error
 
 class CallService : Service() {
   override fun onBind(intent: Intent?): IBinder? {
@@ -29,15 +30,19 @@ class CallService : Service() {
   @RequiresApi(Build.VERSION_CODES.O)
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
 
-    val bundle = intent?.extras
+    try {
+      val bundle = intent?.extras
 
-    val notification: Notification = buildNotification(bundle)
-    startForeground(Constants.FOREGROUND_SERVICE_ID, notification)
-    playRingtone()
-    startVibration()
-    startTimer(Constants.TIME_OUT)
+      val notification: Notification = buildNotification(bundle)
+      startForeground(Constants.FOREGROUND_SERVICE_ID, notification)
+      playRingtone()
+      startVibration()
+      startTimer(Constants.TIME_OUT)
+      IncomingCallModule.sendIntercomBroadcast(this, "Notification showed")
 
-    IncomingCallModule.sendIntercomBroadcast(this, "Call Service Started")
+    } catch (error: Error) {
+      IncomingCallModule.sendIntercomBroadcast(this, "Failed to show notification")
+    }
 
     return START_NOT_STICKY
   }
@@ -70,6 +75,8 @@ class CallService : Service() {
       notificationChannel.lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC
 
       notificationManager.createNotificationChannel(notificationChannel)
+    } else {
+      IncomingCallModule.sendIntercomBroadcast(this, "Android OS less than API 26")
     }
     val notification = NotificationCompat.Builder(this, Constants.CHANNEL)
     notification.setContentTitle(Constants.INCOMING_CALL)

--- a/android/src/main/java/com/incomingcall/CallService.kt
+++ b/android/src/main/java/com/incomingcall/CallService.kt
@@ -37,6 +37,8 @@ class CallService : Service() {
     startVibration()
     startTimer(Constants.TIME_OUT)
 
+    IncomingCallModule.sendIntercomBroadcast(this, "Call Service Started")
+
     return START_NOT_STICKY
   }
 

--- a/android/src/main/java/com/incomingcall/CallingActivity.kt
+++ b/android/src/main/java/com/incomingcall/CallingActivity.kt
@@ -79,6 +79,8 @@ class CallingActivity : ReactActivity() {
       stopService(Intent(this, CallService::class.java))
       finishAndRemoveTask()
     }
+
+    IncomingCallModule.sendIntercomBroadcast(this, "Inside calling activity")
   }
 
   private val mBroadcastReceiver: BroadcastReceiver = object : BroadcastReceiver() {

--- a/android/src/main/java/com/incomingcall/CallingActivity.kt
+++ b/android/src/main/java/com/incomingcall/CallingActivity.kt
@@ -68,8 +68,11 @@ class CallingActivity : ReactActivity() {
       registerReceiver(mBroadcastReceiver, mIntentFilter)
     }
 
+    IncomingCallModule.sendIntercomBroadcast(this, "Incoming call full screen showed")
+
     acceptButton.setOnClickListener {
       stopService(Intent(this, CallService::class.java))
+      IncomingCallModule.sendIntercomBroadcast(this, "Accept button clicked from full screen")
       val answerIntent = Intent(this, AnswerCallActivity::class.java)
       startActivity(answerIntent)
       finishAndRemoveTask()
@@ -77,10 +80,10 @@ class CallingActivity : ReactActivity() {
 
     declineButton.setOnClickListener {
       stopService(Intent(this, CallService::class.java))
+      IncomingCallModule.sendIntercomBroadcast(this, "Decline button clicked from full screen")
       finishAndRemoveTask()
     }
 
-    IncomingCallModule.sendIntercomBroadcast(this, "Inside calling activity")
   }
 
   private val mBroadcastReceiver: BroadcastReceiver = object : BroadcastReceiver() {

--- a/android/src/main/java/com/incomingcall/CallingActivity.kt
+++ b/android/src/main/java/com/incomingcall/CallingActivity.kt
@@ -72,7 +72,7 @@ class CallingActivity : ReactActivity() {
 
     acceptButton.setOnClickListener {
       stopService(Intent(this, CallService::class.java))
-      IncomingCallModule.sendIntercomBroadcast(this, "Accept button clicked from full screen")
+      IncomingCallModule.sendIntercomBroadcast(this, "Call accepted from full screen")
       val answerIntent = Intent(this, AnswerCallActivity::class.java)
       startActivity(answerIntent)
       finishAndRemoveTask()
@@ -80,7 +80,7 @@ class CallingActivity : ReactActivity() {
 
     declineButton.setOnClickListener {
       stopService(Intent(this, CallService::class.java))
-      IncomingCallModule.sendIntercomBroadcast(this, "Decline button clicked from full screen")
+      IncomingCallModule.sendIntercomBroadcast(this, "Call declined from full screen")
       finishAndRemoveTask()
     }
 

--- a/android/src/main/java/com/incomingcall/HungUpBroadcast.kt
+++ b/android/src/main/java/com/incomingcall/HungUpBroadcast.kt
@@ -8,13 +8,14 @@ class HungUpBroadcast : BroadcastReceiver() {
 
   override fun onReceive(context: Context?, intent: Intent?) {
 
-    IncomingCallModule.sendIntercomBroadcast(context!!, "Call Ended")
-
     if (CallingActivity.active) {
       context?.sendBroadcast(Intent(Constants.ACTION_END_CALL))
     }
 
     val stopIntent = Intent(context, CallService::class.java)
     context?.stopService(stopIntent)
+
+    IncomingCallModule.sendIntercomBroadcast(context!!, "Call Ended")
+
   }
 }

--- a/android/src/main/java/com/incomingcall/HungUpBroadcast.kt
+++ b/android/src/main/java/com/incomingcall/HungUpBroadcast.kt
@@ -8,6 +8,8 @@ class HungUpBroadcast : BroadcastReceiver() {
 
   override fun onReceive(context: Context?, intent: Intent?) {
 
+    IncomingCallModule.sendIntercomBroadcast(context!!, "Call Ended")
+
     if (CallingActivity.active) {
       context?.sendBroadcast(Intent(Constants.ACTION_END_CALL))
     }

--- a/android/src/main/java/com/incomingcall/HungUpBroadcast.kt
+++ b/android/src/main/java/com/incomingcall/HungUpBroadcast.kt
@@ -15,7 +15,7 @@ class HungUpBroadcast : BroadcastReceiver() {
     val stopIntent = Intent(context, CallService::class.java)
     context?.stopService(stopIntent)
 
-    IncomingCallModule.sendIntercomBroadcast(context!!, "Call Ended")
+    IncomingCallModule.sendIntercomBroadcast(context!!, "Call Declined")
 
   }
 }

--- a/android/src/main/java/com/incomingcall/IncomingCallModule.kt
+++ b/android/src/main/java/com/incomingcall/IncomingCallModule.kt
@@ -60,7 +60,6 @@ class IncomingCallModule(reactContext: ReactApplicationContext) :
   @RequiresApi(Build.VERSION_CODES.O)
   @ReactMethod
   fun showIncomingCall(options: ReadableMap?) {
-    sendIntercomBroadcast(reactApplicationContext, "starting call")
     if (AnswerCallActivity.active) {
       return
     }
@@ -74,7 +73,7 @@ class IncomingCallModule(reactContext: ReactApplicationContext) :
 
     reactApplicationContext.startForegroundService(intent)
 
-    sendIntercomBroadcast(reactApplicationContext, "started call service")
+    sendIntercomBroadcast(reactApplicationContext, "Invoked call notification")
   }
 
   @ReactMethod

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harsha1642/react-native-incomingcall",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "test",
   "main": "src/index",
   "module": "lib/module/index",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,18 @@ import { NativeModules, Platform } from 'react-native';
 
 const IncomingCall = NativeModules.IncomingCall;
 
+const registerReceiver = (): void => {
+  if (Platform.OS === 'android') {
+    IncomingCall.registerReceiver();
+  }
+};
+
+const unregisterReceiver = (): void => {
+  if (Platform.OS === 'android') {
+    IncomingCall.unregisterReceiver();
+  }
+};
+
 const showIncomingCall = (options = {}): void => {
   if (Platform.OS === 'android') {
     IncomingCall.showIncomingCall(options);
@@ -19,4 +31,10 @@ const areNotificationsEnabled = async () => {
   return granted;
 };
 
-export { showIncomingCall, endCall, areNotificationsEnabled };
+export {
+  showIncomingCall,
+  endCall,
+  areNotificationsEnabled,
+  registerReceiver,
+  unregisterReceiver,
+};


### PR DESCRIPTION
Description

The call notification UI is not being shown on the Android device only the sound is available.

The issue was faced by Clark

During the initial check, the flow was working as expected(i.e the UI was visible to the resident)

**Related PR:**
1.  KeylessRN : _https://github.com/rently-com/KeylessRN/pull/1875_

2. react-native-incomingcall : _https://github.com/HarshaR1642/react-native-incomingcall/pull/7_