### PR TITLE
AVAT-1487 [Resident call is not getting in full screen, when the (Android) mobile in lock mode]

### DIFF
--- a/android/src/main/java/com/incomingcall/CallService.kt
+++ b/android/src/main/java/com/incomingcall/CallService.kt
@@ -78,6 +78,7 @@ class CallService : Service() {
     } else {
       IncomingCallModule.sendIntercomBroadcast(this, "Android OS less than API 26")
     }
+
     val notification = NotificationCompat.Builder(this, Constants.CHANNEL)
     notification.setContentTitle(Constants.INCOMING_CALL)
     notification.setTicker(Constants.INCOMING_CALL)
@@ -89,6 +90,7 @@ class CallService : Service() {
     notification.setStyle(NotificationCompat.DecoratedCustomViewStyle())
     notification.setCustomContentView(customView)
     notification.setCustomBigContentView(customView)
+    notification.setPriority(NotificationCompat.PRIORITY_HIGH) // Set notification priority to high to show in power saving mode
     notification.color = 0XF9F9FC
 
     return notification.build()


### PR DESCRIPTION
Description

Resident calls are not getting in full screen when the (Android) mobile is in lock screen.

The only ringing sound is getting for the resident.

Steps to reproduce:

As a visitor, scan the QR code 

Make a call to the resident.

As the resident make the mobile in lock mode

Expected result: The Resident should get the incoming call in full screen when the screen is in lock mode.

Actual result:  Resident calls are not getting in full screen when the (Android) mobile is in lock screen.

The only ringing sound is getting for the resident.

Device:  Pixel 4a(14) , pixel 6a (13) , galaxy A52 5g ( 14) - Android

Attachments (1)


