### PR TITLE
AVAT-1935 [In Android devices the intercom call is not getting received and the app is crashing]

### DIFF
--- a/android/src/main/java/com/incomingcall/AnswerCallActivity.kt
+++ b/android/src/main/java/com/incomingcall/AnswerCallActivity.kt
@@ -57,7 +57,7 @@ class AnswerCallActivity : ReactActivity() {
     val mIntentFilter = IntentFilter();
     mIntentFilter.addAction(Constants.ACTION_END_CALL);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      registerReceiver(mBroadcastReceiver, mIntentFilter, Context.RECEIVER_NOT_EXPORTED)
+      registerReceiver(mBroadcastReceiver, mIntentFilter, Context.RECEIVER_EXPORTED)
     } else {
       registerReceiver(mBroadcastReceiver, mIntentFilter)
     }

--- a/android/src/main/java/com/incomingcall/CallingActivity.kt
+++ b/android/src/main/java/com/incomingcall/CallingActivity.kt
@@ -63,7 +63,7 @@ class CallingActivity : ReactActivity() {
     val mIntentFilter = IntentFilter();
     mIntentFilter.addAction(Constants.ACTION_END_CALL);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      registerReceiver(mBroadcastReceiver, mIntentFilter, Context.RECEIVER_NOT_EXPORTED)
+      registerReceiver(mBroadcastReceiver, mIntentFilter, Context.RECEIVER_EXPORTED)
     } else {
       registerReceiver(mBroadcastReceiver, mIntentFilter)
     }


### PR DESCRIPTION
**Description**
In Android devices the intercom call is not getting received and the app is crashing.

Steps to reproduce:
1. Login to smart home app as resident/ Agent.
2. Now from another device as visitor initiate an intercom call to that resident

Expected Result:
The intercom call should be received

Actual Result:
THe intercom call is not getting received
IF the app is opened during the visitor makes the call, the app gets crashed 

Jira: https://rently.atlassian.net/browse/AVAT-1935